### PR TITLE
this commit implements CI-integration, and locks the nixpkgs version …

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,0 +1,3 @@
+if builtins?getFlake
+then (builtins.getFlake (toString ./.)).ciNix
+else (import ./flake-compat.nix).defaultNix.ciNix

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,0 +1,9 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+  flake-compat = builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+in
+import flake-compat { src = ./.; }

--- a/flake.lock
+++ b/flake.lock
@@ -83,6 +83,37 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat-ci": {
+      "locked": {
+        "lastModified": 1641672839,
+        "narHash": "sha256-Bdwv+DKeEMlRNPDpZxSz0sSrqQBvdKO5fZ8LmvrgCOU=",
+        "owner": "hercules-ci",
+        "repo": "flake-compat-ci",
+        "rev": "e832114bc18376c0f3fa13c19bf5ff253cc6570a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-compat-ci",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1638122382,
@@ -159,8 +190,7 @@
         "hpc-coveralls": "hpc-coveralls",
         "nix-tools": "nix-tools",
         "nixpkgs": [
-          "haskellNix",
-          "nixpkgs-2111"
+          "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
@@ -298,6 +328,8 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-compat-ci": "flake-compat-ci",
         "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",
         "nixpkgs": [


### PR DESCRIPTION
@morganthomas and @nixinator / @MatthewCroughan - please review this PR before merging.

To provide CI-integration it became needed to lock the nixpkgs version; the current implementation of haskellNix will fail during flake-building.
@locallycompact provided me the useful hint as to how to solve the problem; and it seems to build fine both on a flakes enabled machine, and on a non-flakes machine.

That said, I'm not sure what implications this may have for haskell development.