### PR TITLE
orTestCase and addTestCase

### DIFF
--- a/test/TinyRAM/Spec/EndToEndSpec.hs
+++ b/test/TinyRAM/Spec/EndToEndSpec.hs
@@ -40,7 +40,7 @@ spec = describe "TinyRAM end to end" $ do
   --negativeTestCase
   --negative8bitTestCase
   --breakWKconstraintTestCase
-  --orTestCase
+  orTestCase
   --xorTestCase
   --addTestNegative
   --subTestCase
@@ -521,6 +521,19 @@ cmpaGreaterTestCase =
   --negative8bitTestCase
   --breakWKconstraintTestCase
   --orTestCase
+
+orTestCase :: Spec
+orTestCase =
+  it "answers 63" $ do
+    let program =
+          construct
+            [ Mov (reg' 1) (imm 58),
+              Or (reg' 2) (reg' 1) (imm 15),
+              Answer (reg 1)
+            ]
+    answer <- execute program (InputTape []) (InputTape [])
+    answer `shouldBe` Right 63
+  
   --xorTestCase
   --addTestNegative
   --subTestCase

--- a/test/TinyRAM/Spec/EndToEndSpec.hs
+++ b/test/TinyRAM/Spec/EndToEndSpec.hs
@@ -42,7 +42,7 @@ spec = describe "TinyRAM end to end" $ do
   --breakWKconstraintTestCase
   orTestCase
   --xorTestCase
-  --addTestNegative
+  addTestNegativeTestCase
   --subTestCase
   --notTestCase
   --mullTestCase
@@ -520,22 +520,32 @@ cmpaGreaterTestCase =
   --negativeTestCase
   --negative8bitTestCase
   --breakWKconstraintTestCase
-  --orTestCase
 
 orTestCase :: Spec
 orTestCase =
   it "answers 63" $ do
     let program =
           construct
-            [ Mov (reg' 1) (imm 58),
-              Or (reg' 2) (reg' 1) (imm 15),
-              Answer (reg 1)
+            [ Mov (reg' 2) (imm 58),
+              Or (reg' 0) (reg' 2) (imm 15),
+              Answer (reg 0)
             ]
     answer <- execute program (InputTape []) (InputTape [])
     answer `shouldBe` Right 63
   
   --xorTestCase
-  --addTestNegative
+addTestNegativeTestCase :: Spec
+addTestNegativeTestCase =
+  it "answers 3" $ do
+    let program =
+          construct
+            [ Mov (reg' 1) (imm 5),
+              Add (reg' 0) (reg' 1) (imm (negate 2)),
+              Answer (reg 0)
+            ]
+    answer <- execute program (InputTape []) (InputTape [])
+    answer `shouldBe` Right 3
+  
   --subTestCase
   --notTestCase
   --mullTestCase


### PR DESCRIPTION
I've found that in some cases, register 0 must be used for the answer line. Both of the reported answers from Coq and TinyRam are wrong, and should be 63.