### PR TITLE
Cmpae equal test case l bug

### DIFF
--- a/test/TinyRAM/Spec/EndToEndSpec.hs
+++ b/test/TinyRAM/Spec/EndToEndSpec.hs
@@ -58,6 +58,7 @@ spec = describe "TinyRAM end to end" $ do
   shrTestCase
 
   cmpaeEqualTestCaseE
+  cmpaeEqualTestCaseL
   cmpaeEqualTestCaseG
 
   cmpaeGreaterTestCase
@@ -233,6 +234,22 @@ cmpaeEqualTestCaseE =
             ]
     answer <- execute program (InputTape []) (InputTape [])
     answer `shouldBe` Right 1
+
+cmpaeEqualTestCaseL :: Spec
+cmpaeEqualTestCaseL =
+  it "answers 0" $ do
+    let program =
+          construct
+            [ Mov (reg' 0) (imm 0),
+              Mov (reg' 2) (imm 1),
+              Mov (reg' 3) (imm 2),
+              Cmpae (reg' 2) (reg 3),
+              Cmov (reg' 0) (imm 1),
+              Answer (reg 0)
+            ]
+    answer <- execute program (InputTape []) (InputTape [])
+    answer `shouldBe` Right 0
+
 
 cmpaeEqualTestCaseG :: Spec
 cmpaeEqualTestCaseG =

--- a/test/TinyRAM/Spec/EndToEndSpec.hs
+++ b/test/TinyRAM/Spec/EndToEndSpec.hs
@@ -57,8 +57,9 @@ spec = describe "TinyRAM end to end" $ do
   shlFlagTestCase
   shrTestCase
 
-  cmpaeEqualTestCase0 
-  cmpaeEqualTestCase1
+  cmpaeEqualTestCaseE
+  cmpaeEqualTestCaseG
+
   cmpaeGreaterTestCase
   --cmpaeLessTestCase --bugged reported
   --cmpaeNegTestCase  --bugged reported
@@ -218,8 +219,8 @@ cjmpTestCase =
 --cmov r1, 1
 --answer r1
 
-cmpaeEqualTestCase1 :: Spec
-cmpaeEqualTestCase1 =
+cmpaeEqualTestCaseE :: Spec
+cmpaeEqualTestCaseE =
   it "answers 1" $ do
     let program =
           construct
@@ -233,8 +234,8 @@ cmpaeEqualTestCase1 =
     answer <- execute program (InputTape []) (InputTape [])
     answer `shouldBe` Right 1
 
-cmpaeEqualTestCase0 :: Spec
-cmpaeEqualTestCase0 =
+cmpaeEqualTestCaseG :: Spec
+cmpaeEqualTestCaseG =
   it "answers 1" $ do
     let program =
           construct

--- a/test/TinyRAM/Spec/EndToEndSpec.hs
+++ b/test/TinyRAM/Spec/EndToEndSpec.hs
@@ -57,7 +57,8 @@ spec = describe "TinyRAM end to end" $ do
   shlFlagTestCase
   shrTestCase
 
-  cmpaeEqualTestCase
+  cmpaeEqualTestCase0 
+  cmpaeEqualTestCase1
   cmpaeGreaterTestCase
   --cmpaeLessTestCase --bugged reported
   --cmpaeNegTestCase  --bugged reported
@@ -217,14 +218,29 @@ cjmpTestCase =
 --cmov r1, 1
 --answer r1
 
-cmpaeEqualTestCase :: Spec
-cmpaeEqualTestCase =
+cmpaeEqualTestCase1 :: Spec
+cmpaeEqualTestCase1 =
   it "answers 1" $ do
     let program =
           construct
             [ Mov (reg' 0) (imm 0),
               Mov (reg' 2) (imm 2),
               Mov (reg' 3) (imm 2),
+              Cmpae (reg' 2) (reg 3),
+              Cmov (reg' 0) (imm 1),
+              Answer (reg 0)
+            ]
+    answer <- execute program (InputTape []) (InputTape [])
+    answer `shouldBe` Right 1
+
+cmpaeEqualTestCase0 :: Spec
+cmpaeEqualTestCase0 =
+  it "answers 1" $ do
+    let program =
+          construct
+            [ Mov (reg' 0) (imm 0),
+              Mov (reg' 2) (imm 2),
+              Mov (reg' 3) (imm 1),
               Cmpae (reg' 2) (reg 3),
               Cmov (reg' 0) (imm 1),
               Answer (reg 0)


### PR DESCRIPTION
This demonstrates the discrepancy between coq and haskell with the cmpaeEqualTestCaseL. Coq incorrectly answers 1 and haskell correctly answers 0.